### PR TITLE
Fixed bug: layer names which will be finetuned

### DIFF
--- a/models/resnext.py
+++ b/models/resnext.py
@@ -140,7 +140,7 @@ def get_fine_tuning_parameters(model, ft_begin_index):
 
     ft_module_names = []
     for i in range(ft_begin_index, 5):
-        ft_module_names.append('layer{}'.format(ft_begin_index))
+        ft_module_names.append('layer{}'.format(i))
     ft_module_names.append('fc')
 
     parameters = []


### PR DESCRIPTION
Hi! Again thanks for your amazing repo! 
I am confused in this part. Please review this PR carefully. 
I think:
ft_module_names.append('layer{}'.format(ft_begin_index)) 
should be
ft_module_names.append('layer{}'.format(i))
, but it is the same in all models in models folder. Is it intentional?
But if I set ft_begin_index=3, it never becomes 4, so the 4th channel will remain the same, right? Maybe, I misunderstood the code.