### PR TITLE
[fix] train/lr logging

### DIFF
--- a/training.py
+++ b/training.py
@@ -103,4 +103,4 @@ def train_epoch(epoch,
     if tb_writer is not None:
         tb_writer.add_scalar('train/loss', losses.avg, epoch)
         tb_writer.add_scalar('train/acc', accuracies.avg, epoch)
-        tb_writer.add_scalar('train/lr', accuracies.avg, epoch)
+        tb_writer.add_scalar('train/lr', current_lr, epoch)


### PR DESCRIPTION
Fix `train/lr` logging which was `accuracies.avg` not `current_lr` on Tensorboard.